### PR TITLE
refactor: move tag format logic to earlier step in lookup

### DIFF
--- a/semantic_release/history/__init__.py
+++ b/semantic_release/history/__init__.py
@@ -35,25 +35,18 @@ def get_pattern_with_commit_subject(pattern):
 
 
 def get_version_pattern():
-    # prerelease_pattern = get_prerelease_pattern()
-    # return rf"(\d+\.\d+\.\d+({prerelease_pattern})?)"
-    return _version_pattern()
+    prerelease_pattern = get_prerelease_pattern()
+    return rf"(\d+\.\d+\.\d+({prerelease_pattern})?)"
 
 
 def get_release_version_pattern():
-    # prerelease_pattern = get_prerelease_pattern()
-    # return rf"v?(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
-    return _version_pattern()
+    prerelease_pattern = get_prerelease_pattern()
+    return rf"v?(\d+\.\d+\.\d+(?!.*{prerelease_pattern}))"
 
-
-def _version_pattern():
+def get_tag_pattern():
     version = r"(\d+\.\d+\.\d+?)"
-    if "tag_format" in config:
-        tag_format = config.get("tag_format")
-        return tag_format.format(version=version)
-    else:
-        prerelease_pattern = get_prerelease_pattern()
-        return rf"v?({version}?!.*{prerelease_pattern}))"
+    tag_format = config.get("tag_format")
+    return tag_format.format(version=version)
 
 
 def get_commit_release_version_pattern():
@@ -218,7 +211,7 @@ def get_current_version_by_tag() -> str:
 
     :return: A string with the version number or 0.0.0 on failure.
     """
-    version = get_last_version(pattern=get_version_pattern())
+    version = get_last_version(pattern=get_tag_pattern())
     if version:
         return version
 
@@ -233,7 +226,7 @@ def get_current_release_version_by_tag() -> str:
 
     :return: A string with the version number or 0.0.0 on failure.
     """
-    version = get_last_version(pattern=get_release_version_pattern())
+    version = get_last_version(pattern=get_tag_pattern())
     if version:
         return version
 


### PR DESCRIPTION
The existing tag format logic removed the ability to match regular patterns in strings with `{version}`, such as the commit message lookup.
This change checks a different function when searching by tags, which uses the `tag_format` value in the pattern. 